### PR TITLE
Added cors middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,5 @@ POSTGRES_PASSWORD=laguan
 POSTGRES_DB_URL=0.0.0.0
 POSTGRES_DB=postgres
 DATABASE_URL=postgres://postgres@localhost/../error-microservice/
+
+CORS_ORIGIN=localhost:8080

--- a/.env.example
+++ b/.env.example
@@ -9,4 +9,4 @@ POSTGRES_DB_URL=0.0.0.0
 POSTGRES_DB=postgres
 DATABASE_URL=postgres://postgres@localhost/../error-microservice/
 
-CORS_ORIGIN=localhost:8080
+WHITELIST=localhost:8080

--- a/docs/CORS.md
+++ b/docs/CORS.md
@@ -1,16 +1,16 @@
 # CORS middleware
 
-To allow sites in the CORS middleware go to the project's root and create a `.env` file, then add the `CORS_ORIGIN` key.
+To allow sites in the CORS middleware go to the project's root and create a `.env` file, then add the `WHITELIST` key.
 
 For example:
 
 ```
 // .env
-CORS_ORIGIN=127.0.0.1
+WHITELIST=127.0.0.1
 ```
 
 You can add multiple sites using commas between each site, for example:
 
 ```
-CORS_ORIGIN=127.0.0.1,https://doc.rust-lang.org
+WHITELIST=127.0.0.1,https://doc.rust-lang.org
 ```

--- a/docs/CORS.md
+++ b/docs/CORS.md
@@ -1,0 +1,16 @@
+# CORS middleware
+
+To allow sites in the CORS middleware go to the project's root and create a `.env` file, then add the `CORS_ORIGIN` key.
+
+For example:
+
+```
+// .env
+CORS_ORIGIN=127.0.0.1
+```
+
+You can add multiple sites using commas between each site, for example:
+
+```
+CORS_ORIGIN=127.0.0.1,https://doc.rust-lang.org
+```

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,13 +5,13 @@ use thruster::{m, App, ThrusterServer};
 pub mod configuration;
 pub mod logger;
 mod middlewares;
-use middlewares::{helmet, json_error_handler, profile};
+use middlewares::{cors, helmet, json_error_handler, profile};
 
 use crate::routes::controllers::{four_oh_four, plaintext};
 
 pub fn init_app(/*is_prod: bool*/) -> App<HyperRequest, Ctx, ()> {
     App::<HyperRequest, Ctx, ()>::create(generate_context, ())
-        .use_middleware("/", m![json_error_handler, helmet, profile])
+        .use_middleware("/", m![json_error_handler, helmet, profile, cors])
 }
 
 pub fn init_routes(app: App<HyperRequest, Ctx, ()>) -> App<HyperRequest, Ctx, ()> {

--- a/src/server/middlewares.rs
+++ b/src/server/middlewares.rs
@@ -137,9 +137,10 @@ pub async fn cors(mut context: Ctx, next: MiddlewareNext<Ctx>) -> MiddlewareResu
             .request
             .headers()
             .get("Origin")
-            .map(|header_values| header_values.to_str().unwrap().to_string())
-            .unwrap();
-        origin_env.split(',').find(|v| v == &header).unwrap_or("*")
+            .map(|origin| origin.to_str().unwrap().to_string())
+            .unwrap_or_else(|| "*".to_string());
+
+        origin_env.split(',').find(|v| v == &header).unwrap_or("")
     } else {
         &origin_env
     };

--- a/src/server/middlewares.rs
+++ b/src/server/middlewares.rs
@@ -127,7 +127,7 @@ pub async fn helmet(mut context: Ctx, next: MiddlewareNext<Ctx>) -> MiddlewareRe
 
 #[middleware]
 pub async fn cors(mut context: Ctx, next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
-    let origin_env = std::env::var("CORS_ORIGIN").unwrap_or_else(|_| "*".to_string());
+    let origin_env = std::env::var("WHITELIST").unwrap_or_else(|_| "*".to_string());
 
     let origin = if origin_env.contains(',') {
         let header = context


### PR DESCRIPTION
I added the middleware to handle the `access-control-allow-origin` header, so block the requests from unexpected origins.

Now you can add the allowed sites in the .env file separated by commas `,`

---

I tested this by giving access to the Rust documentation and making a request to the endpoint: 

![imagen](https://user-images.githubusercontent.com/66505715/189508576-36bbe58b-7885-4d20-baa4-ffe00f39530b.png)

And then making a request from an unexpected website:

![imagen](https://user-images.githubusercontent.com/66505715/189508592-e76c8da8-40a6-4d97-ab2b-a561286ca48b.png)
